### PR TITLE
Remove @discordjs/builders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
 			"name": "drpg-template",
 			"version": "2.0.1-dev",
 			"dependencies": {
-				"@discordjs/builders": "^1.7.0",
 				"@sapphire/decorators": "^6.0.2",
 				"@sapphire/framework": "^4.8.2",
 				"discord.js": "^14.14.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
 		"prepare": "husky install"
 	},
 	"dependencies": {
-		"@discordjs/builders": "^1.7.0",
 		"@sapphire/decorators": "^6.0.2",
 		"@sapphire/framework": "^4.8.2",
 		"discord.js": "^14.14.1",


### PR DESCRIPTION
Causes issues when importing references that exist in both the discordjs and the discordjs/builders namespaces, typically with `colorResolvable` or `EmbedBuilder`
