### PR TITLE
Updated ping command example

### DIFF
--- a/src/commands/general/PingCommand.ts
+++ b/src/commands/general/PingCommand.ts
@@ -1,21 +1,39 @@
 import { ApplyOptions } from "@sapphire/decorators";
+import { ApplicationCommandRegistry, Command } from "@sapphire/framework";
 import { Message } from "discord.js";
 import { DrpgCommand, IDrpgCommandOptions } from "../../lib/structures/DrpgCommand";
+import { DrpgCommandRequest } from "../../lib/structures/DrpgCommandRequest";
+import { DrpgResponse } from "../../lib/structures/RichEmbed";
 
 @ApplyOptions<IDrpgCommandOptions>({
-	aliases: ["latency", "ms", "ping"],
+	name: "ping",
+	aliases: ["latency", "ms"],
 	fullCategory: ["Debug"],
 	showInHelpMenu: true,
-	description: "Checks the bot's response time.",
+	shortDesc: "Checks the bot's response time.",
 })
 export class PingCommand extends DrpgCommand {
-	public async messageRun(message: Message): Promise<Message> {
-		const msg = await message.channel.send("Ping..");
+	public override async registerApplicationCommands(registry: ApplicationCommandRegistry) {
+		registry.registerChatInputCommand((builder) => builder.setName(this.name).setDescription((this.options as IDrpgCommandOptions).shortDesc));
+	}
 
-		const content = `Bot Latency ${Math.round(this.container.client.ws.ping)}ms. API Latency ${
-			(msg.editedTimestamp || msg.createdTimestamp) - (message.editedTimestamp || message.createdTimestamp)
-		}ms`;
+	public async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
+		const request = new DrpgCommandRequest(interaction, this);
 
-		return msg.edit(content);
+		const response = await this.pingCommandResponse(request);
+		return await request.respond(response, false);
+	}
+
+	async messageRun(message: Message): Promise<Message> {
+		const request = new DrpgCommandRequest(message, this);
+
+		const response = await this.pingCommandResponse(request);
+
+		return await request.respond(response, false);
+	}
+
+	async pingCommandResponse(request: DrpgCommandRequest): Promise<DrpgResponse> {
+		const content = `Bot Latency ${Math.round(this.container.client.ws.ping)}ms.`;
+		return content;
 	}
 }


### PR DESCRIPTION
The ping command has now been updated following the `DrpgResponse` improvement made in #6

the ping command is now a good example to follow if you want to create 'Rich Commands' - commands that support both slash and message commands.

These types of commands are best of gathering *only* the required parameters (parsing the `args`) from the message or the interaction - and then passing off into a common, shared implementation - meaning the logic is only required once, and it will support both.

It's now a clean and easily readable example that includes
- `DrpgResponse`
- Configuration of a Slash Command (`ChatInputcommand`)
- configuration of a prefix command (`messageRun`)
- Both entry points share the same output and processing
